### PR TITLE
Avoid generating aliases in YAML

### DIFF
--- a/tests/test_yaml_blob.py
+++ b/tests/test_yaml_blob.py
@@ -16,6 +16,17 @@ class YamlBlobWithNewlines(YamlBlob):
         }
 
 
+class YamlBlobWithSharedObjects(YamlBlob):
+    """Defines a YamlBlob class that has keys pointing at the same object."""
+
+    def data(self):
+        shared = {"foo": "bar"}
+        return {
+            "a": shared,
+            "b": shared,
+        }
+
+
 class TestImperativeTemplates(unittest.TestCase):
     """Unit tests for imperative generation."""
 
@@ -28,6 +39,21 @@ blob: |-
   foo
   bar
   baz
+""",
+        )
+
+
+class TestNoAliases(unittest.TestCase):
+    """Unit tests for yaml without aliases."""
+
+    def test_no_aliases_generated(self):
+        obj = YamlBlobWithSharedObjects()
+        self.assertEqual(
+            obj.generate(),
+            """a:
+  foo: bar
+b:
+  foo: bar
 """,
         )
 


### PR DESCRIPTION
Things like `*id001` references don't make sense in YAML that are generated be templatizer, especially for things like K8S manifests.